### PR TITLE
update rspec tests to pass for content controller

### DIFF
--- a/spec/controllers/content_controller_spec.rb
+++ b/spec/controllers/content_controller_spec.rb
@@ -2,24 +2,30 @@ require 'spec_helper'
 
 describe ContentController do
 
+  before (:each) do
+    @user = FactoryGirl.create(:user)
+    sign_in @user
+    @user.add_role :silver # gives the user a role. tests pass regardless of role
+  end
+
   describe "GET 'silver'" do
     it "returns http success" do
       get 'silver'
-      response.should be_success
+      response.should @user.has_role?(:silver) ? be_success : redirect_to(root_url)
     end
   end
 
   describe "GET 'gold'" do
     it "returns http success" do
       get 'gold'
-      response.should be_success
+      response.should @user.has_role?(:gold) ? be_success : redirect_to(root_url)
     end
   end
 
   describe "GET 'platinum'" do
     it "returns http success" do
       get 'platinum'
-      response.should be_success
+      response.should @user.has_role?(:platinum) ? be_success : redirect_to(root_url)
     end
   end
 


### PR DESCRIPTION
Tests would fail since cases were looking for successful response when result was a redirect, which stems from the User role authorization.

Code updates the tests to look for redirection or success response in the case that the User is authorized.
