### PR TITLE
Fix- User.update_plan wont alter Role database

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ActiveRecord::Base
   before_destroy :cancel_subscription
 
   def update_plan(role)
-    self.remove_role(self.roles.first.name)
+    self.role_ids = []
     self.add_role(role.name)
     unless customer_id.nil?
       customer = Stripe::Customer.retrieve(customer_id)

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :role do
+    name 'admin'
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -113,4 +113,24 @@ describe User do
 
   end
 
+  describe "#update_plan" do
+    before do
+      @user = FactoryGirl.create(:user, email: "test@example.com")
+      @role1 = FactoryGirl.create(:role, name: "silver")
+      @role2 = FactoryGirl.create(:role, name: "gold")
+      @user.add_role(@role1.name)
+    end
+
+    it "updates a users role" do
+      @user.roles.first.name.should == "silver"
+      @user.update_plan(@role2)
+      @user.roles.first.name.should == "gold"
+    end
+
+    it "wont remove original role from database" do
+      @user.update_plan(@role2)
+      Role.all.count.should == 2
+    end
+  end
+
 end


### PR DESCRIPTION
This should fix the Roles should be constants issue. I can't figure how to attach this pull request to that issue...
