### PR TITLE
added stripe error div to edit page

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <h2>Account</h2>
-
+<div id="stripe_error" class="alert alert-error" style="display:none" ></div>
 <%= simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, :class => 'form-vertical' }) do |f| %>
   <%= f.error_notification %>
   <%= f.input :name, :autofocus => true %>


### PR DESCRIPTION
Added the stripe error response div to the account/edit page.  Currently stripe errors have no place to display on that page.
