### PR TITLE
Empty validation notification when form is invalid

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@ module ApplicationHelper
   
   def display_base_errors resource
     return '' if resource.errors.empty?
-    messages = resource.errors[:base].map { |msg| content_tag(:p, msg) }.join
+    messages = resource.errors.full_messages.map { |msg| content_tag(:p, msg) }.join
     html = <<-HTML
     <div class="alert alert-error alert-block">
       <button type="button" class="close" data-dismiss="alert">&#215;</button>


### PR DESCRIPTION
resource.errors[:base] return an empty array, use resource.errors.full_messages instead
