### PR TITLE
Allow users to set config variables in development.yml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ db/*.sqlite3
 .sass-cache
 /config/config.yml
 /config/database.yml
+/config/local_env.yml
 /coverage.data
 /coverage/
 /db/*.javadb/

--- a/README.textile
+++ b/README.textile
@@ -280,18 +280,15 @@ Stripe.api_key = ENV["STRIPE_API_KEY"]
 STRIPE_PUBLIC_KEY = ENV["STRIPE_PUBLIC_KEY"]
 </pre>
 
-For security, don't record sensitive information in your application code where it might be exposed publicly on a GitHub repo. Instead, set Unix environment variables in the file that is read when starting an interactive shell (the *~/.bashrc* file for the bash shell). This will keep the password out of your repository.
+For security, don't record sensitive information in your application code where it might be exposed publicly on a GitHub repo.
 
-Add this to your *~/.bashrc* file (or the equivalent file for your preferred Unix shell):
+Instead, rename the file *config/development.example.yml* to *config/development.yml*
 
-<pre>
-export STRIPE_API_KEY="secret"
-export STRIPE_PUBLIC_KEY="secret"
-</pre>
+Open *config/development.yml* and replace "Your_Stripe_API_Key" and "Your_Stripe_Public_Key" with the keys provided by Stripe.
 
-Replace "secret" with your keys. You can find both keys on your "Stripe account page":https://manage.stripe.com/#account/apikeys. Two sets of keys are available: one for testing, one for live transactions. Use the testing keys on your development machine. When you deploy, use the live keys. If you plan to use Heroku for hosting, make a note for yourself to set up the Heroku environment variables after deployment.
+You can find both keys on your "Stripe account page":https://manage.stripe.com/#account/apikeys. Two sets of keys are available: one for testing, one for live transactions. Use the testing keys on your development machine. When you deploy, use the live keys. If you plan to use Heroku for hosting, make a note for yourself to set up the Heroku environment variables after deployment.
 
-Here's how to set Heroku environment variables to provide the same data your application obtains from your local shell environment:
+Here's how to set Heroku environment variables to provide the same data your application obtains from the 'development.yml' file:
 
 <pre>
 $ heroku config:add STRIPE_API_KEY=secret STRIPE_PUBLIC_KEY=secret

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,5 +78,12 @@ module RailsStripeMembershipSaas
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    config.before_configuration do
+      dev = File.join(Rails.root, 'config', 'local_env.yml')
+      YAML.load(File.open(dev)).each do |key, value|
+        ENV[key.to_s] = value
+      end if File.exists?(dev)
+    end
   end
 end

--- a/config/local_env.example.yml
+++ b/config/local_env.example.yml
@@ -1,0 +1,12 @@
+# Rename this file to local_env.yml
+# Add account settings and API keys here.
+# This file is in .gitignore to keep your settings secret!
+# Each entry gets set as a local environment variable.
+# This file overrides ENV variables in the Unix shell.
+# For example, setting:
+# GMAIL_USERNAME: 'Your_Gmail_Username'
+# makes 'Your_Gmail_Username' available as ENV["GMAIL_USERNAME"]
+STRIPE_API_KEY: 'Your_Stripe_API_key'
+STRIPE_PUBLIC_KEY: 'Your_Stripe_Public_Key'
+GMAIL_USERNAME: 'Your_Gmail_Username'
+GMAIL_PASSWORD: 'Your_Gmail_Password'


### PR DESCRIPTION
This may be a better solution than having users setup config variables in their .bashrc. I think setting variables in the .bashrc differs depending on load paths, whether your using rvm or not, etc. This way offers a little easier solution for our newer rails developers. 

That being said, setting them in your .bashrc would still work as well if you remove this file (or just those config variables in this file). Also,  adding your keys to heroku sill works the same way. 

Thoughts?
