### PR TITLE
Fix stripe_config_spec

### DIFF
--- a/spec/stripe/stripe_config_spec.rb
+++ b/spec/stripe/stripe_config_spec.rb
@@ -4,8 +4,8 @@ describe "Config Variables" do
 
   describe "STRIPE_API_KEY" do
 
-    it "should not be nil" do
-      Stripe.api_key.should_not be_nil,
+    it "should be set" do
+      Stripe.api_key.should_not eq("Your_Stripe_API_key"),
         "Your STRIPE_API_KEY is not set, Please refer to the 'Configure the Stripe Initializer' section of the README"
     end
 
@@ -13,8 +13,8 @@ describe "Config Variables" do
 
   describe "STRIPE_PUBLIC_KEY" do
 
-    it "should not be nil" do
-      STRIPE_PUBLIC_KEY.should_not be_nil,
+    it "should be set" do
+      STRIPE_PUBLIC_KEY.should_not eq("Your_Stripe_Public_Key"),
         "Your STRIPE_PUBLIC_KEY is not set, Please refer to the 'Configure the Stripe Initializer' section of the README"
     end
 


### PR DESCRIPTION
Because we are initializing the config variables through the yaml file, the old stripe_config spec file wasn't properly testing they were being set. Now it is. :bowtie:
