### PR TITLE
Fix #49 Creation of new roles by params

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,7 +2,7 @@ class RegistrationsController < Devise::RegistrationsController
 
   def new
     @plan = params[:plan]
-    if @plan
+    if ENV["ROLES"].include?(@plan) && @plan != "admin"
       super
     else
       redirect_to root_path, :notice => 'Please select a subscription plan below.'


### PR DESCRIPTION
I'll come up with a better way for this later, but figured its best to get out a fix quickly as this could be a security issue. without this fix, by going to **/users/sign_up?plan=admin** a user can sign themselves up as an admin. 
