### PR TITLE
Update user_spec to account for pre-existing Roles in database

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -115,6 +115,7 @@ describe User do
 
   describe "#update_plan" do
     before do
+      @number_of_initial_roles = Role.all.count
       @user = FactoryGirl.create(:user, email: "test@example.com")
       @role1 = FactoryGirl.create(:role, name: "silver")
       @role2 = FactoryGirl.create(:role, name: "gold")
@@ -129,7 +130,7 @@ describe User do
 
     it "wont remove original role from database" do
       @user.update_plan(@role2)
-      Role.all.count.should == 2
+      Role.all.count.should == @number_of_initial_roles + 2
     end
   end
 


### PR DESCRIPTION
Updated user_spec to store the number of initial roles in the database before FactoryGirl creates 2 additional ones.  Then we check for the number of roles after the @user role is changes for the number we had before plus the number that we have added (@number_of_initial_roles + 2)
