### PR TITLE
Extract stripe methods to their own model

### DIFF
--- a/app/models/stripe_account.rb
+++ b/app/models/stripe_account.rb
@@ -1,0 +1,71 @@
+class StripeAccount < Struct.new(:user)
+
+  def self.create(user)
+    new(user).create_customer
+  end
+
+  def self.update(user)
+    new(user).update_customer
+  end
+
+  def self.cancel(user)
+    new(user).cancel_customer
+    user.delete
+  end
+
+  def cancel_customer
+    if customer = retrieve_customer
+      unless customer.respond_to?('deleted')
+        customer.cancel_subscription if customer.subscription.status == 'active'
+      end
+    end
+  end
+
+  def retrieve_customer
+    Stripe::Customer.retrieve(user.customer_id) if user.customer_id
+  end
+
+  def update_customer
+    customer = retrieve_customer
+    if user.stripe_token.present?
+      customer.card = user.stripe_token
+    end
+    customer.email = user.email
+    customer.description = user.name
+    customer.save
+    store_user_stripe_info(customer)
+  end
+
+  def store_user_stripe_info(customer)
+    user.last_4_digits = customer.active_card.last4
+    user.customer_id = customer.id
+    user.stripe_token = nil
+  end
+
+  def create_customer
+    raise "Stripe token not present. Can't create account." if user.stripe_token.blank?
+    user.coupon.blank? ? create_customer_without_coupon : create_customer_with_coupon
+  end
+
+  def create_customer_without_coupon
+    customer = Stripe::Customer.create(stripe_params)
+    store_user_stripe_info(customer)
+  end
+
+  def create_customer_with_coupon
+    customer = Stripe::Customer.create(
+      stripe_params.merge(coupon: user.coupon)
+    )
+    store_user_stripe_info(customer)
+  end
+
+  def stripe_params
+    {
+      email: user.email,
+      description: user.name,
+      card: user.stripe_token,
+      plan: user.roles.first.name
+    }
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,8 +16,7 @@ class User < ActiveRecord::Base
     self.role_ids = []
     self.add_role(role.name)
     unless customer_id.nil?
-      customer = Stripe::Customer.retrieve(customer_id)
-      customer.update_subscription(:plan => role.name)
+      StripeAccount.new(self).retrieve_customer.update_subscription(:plan => role.name)
     end
     true
   rescue Stripe::StripeError => e
@@ -25,67 +24,33 @@ class User < ActiveRecord::Base
     errors.add :base, "Unable to update your subscription. #{e.message}."
     false
   end
-  
+
   def update_stripe
     return if email.include?(ENV['ADMIN_EMAIL'])
     return if email.include?('@example.com') and not Rails.env.production?
     if customer_id.nil?
-      if !stripe_token.present?
-        raise "Stripe token not present. Can't create account."
-      end
-      if coupon.blank?
-        customer = Stripe::Customer.create(
-          :email => email,
-          :description => name,
-          :card => stripe_token,
-          :plan => roles.first.name
-        )
-      else
-        customer = Stripe::Customer.create(
-          :email => email,
-          :description => name,
-          :card => stripe_token,
-          :plan => roles.first.name,
-          :coupon => coupon
-        )
-      end
+      customer = StripeAccount.create(self)
     else
-      customer = Stripe::Customer.retrieve(customer_id)
-      if stripe_token.present?
-        customer.card = stripe_token
-      end
-      customer.email = email
-      customer.description = name
-      customer.save
+      customer = StripeAccount.update(self)
     end
-    self.last_4_digits = customer.active_card.last4
-    self.customer_id = customer.id
-    self.stripe_token = nil
   rescue Stripe::StripeError => e
     logger.error "Stripe Error: " + e.message
     errors.add :base, "#{e.message}."
     self.stripe_token = nil
     false
   end
-  
+
   def cancel_subscription
-    unless customer_id.nil?
-      customer = Stripe::Customer.retrieve(customer_id)
-      unless customer.nil? or customer.respond_to?('deleted')
-        if customer.subscription.status == 'active'
-          customer.cancel_subscription
-        end
-      end
-    end
+    StripeAccount.cancel(self)
   rescue Stripe::StripeError => e
     logger.error "Stripe Error: " + e.message
     errors.add :base, "Unable to cancel your subscription. #{e.message}."
     false
   end
-  
+
   def expire
     UserMailer.expire_email(self).deliver
     destroy
   end
-  
+
 end

--- a/features/users/sign_up_with_stripe.feature
+++ b/features/users/sign_up_with_stripe.feature
@@ -66,5 +66,3 @@ Feature: User signs up with stripe
       When I press "Sign up"
       Then I should be on the "user registration" page
       And I should see "declined"
-
-

--- a/spec/models/stripe_account_spec.rb
+++ b/spec/models/stripe_account_spec.rb
@@ -1,0 +1,121 @@
+require 'spec_helper'
+
+describe StripeAccount do
+
+  describe "#stripe_params" do
+    it "returns a hash of params for stripe" do
+      user = FactoryGirl.create(:user, email: "test@example.com")
+      user.stub_chain(:roles, :first, :name).and_return("Silver")
+      StripeAccount.new(user).stripe_params.should == {
+        :email=>"test@example.com",
+        :description=>"Test User",
+        :card=>nil,
+        :plan=>"Silver"
+      }
+    end
+  end
+
+  describe "#cancel_customer" do
+    before do
+      user = FactoryGirl.create(:user, email: "test@example.com", customer_id: '12345')
+      @account = StripeAccount.new(user)
+      @customer = double(:customer, deleted: deleted)
+      @customer.stub_chain("subscription.status").and_return("active")
+      Stripe::Customer.stub(:retrieve).and_return(@customer)
+    end
+
+    context "with a deleted customer" do
+      let(:deleted) { true }
+      it "returns nil" do
+        @account.cancel_customer.should be_nil
+      end
+    end
+
+    context "with a found customer" do
+      let(:deleted) { false }
+      it "cancels the customer" do
+        expect{@customer.to_recieve(:cancel_subscription)}
+        @account.cancel_customer
+      end
+    end
+  end
+
+  describe ".cancel" do
+    before do
+      @user = FactoryGirl.create(:user, email: "test@example.com", customer_id: '12345')
+      customer = double(:customer, deleted: true)
+      Stripe::Customer.stub(:retrieve).and_return(customer)
+    end
+
+    it "deletes the user from the database" do
+      expect{ StripeAccount.cancel(@user) }.to change{ User.count }.by(-1)
+    end
+  end
+
+  describe '#create_customer' do
+
+    context 'with stripe token not present' do
+      it "raises an error if stripe token is not present" do
+        user = double(:user, stripe_token: '')
+        expect{StripeAccount.create(user)}.to raise_error
+      end
+    end
+
+    context 'with stripe token present' do
+      let(:stripe_account) { StripeAccount.new(user) }
+      let(:user) do
+        FactoryGirl.create(:user,
+                           email: "test@example.com",
+                           stripe_token: '54321',
+                           name: 'tester',
+                           coupon: coupon)
+      end
+      before do
+        successful_stripe_response = StripeHelper::Response.new("success")
+        Stripe::Customer.stub(:create).and_return(successful_stripe_response)
+        role = FactoryGirl.create(:role, name: "silver")
+        user.add_role(role.name)
+      end
+
+      context 'user without a coupon' do
+        let(:coupon) {""}
+        it "creates a user without coupon" do
+          stripe_account.should_receive(:create_customer_without_coupon)
+          stripe_account.create_customer
+        end
+      end
+
+      context 'user with a coupon' do
+        let(:coupon) {"free-month"}
+        it "creates a user without coupon" do
+          stripe_account.should_receive(:create_customer_with_coupon)
+          stripe_account.create_customer
+        end
+      end
+    end
+
+    describe 'create_customer_without_coupon' do
+      let(:user) do
+        FactoryGirl.create(:user,
+                           email: "test@example.com",
+                           stripe_token: '54321',
+                           name: 'tester',
+                           coupon: '')
+      end
+      before do
+        successful_stripe_response = StripeHelper::Response.new("success")
+        Stripe::Customer.stub(:create).and_return(successful_stripe_response)
+        role = FactoryGirl.create(:role, name: "silver")
+        user.add_role(role.name)
+      end
+      let(:stripe_account) { StripeAccount.new(user) }
+
+      it "stores a users stripe information" do
+        stripe_account.create_customer_without_coupon
+        user.customer_id.should eq("youAreSuccessful")
+        user.last_4_digits.should eq("4242")
+        user.stripe_token.should be_nil
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -133,28 +133,22 @@ describe User do
     end
   end
 
-
   describe ".update_stripe" do
-
-
     context "with a non-existing user" do
-
-      before do
-        successful_stripe_response = StripeHelper::Response.new("success")
-        Stripe::Customer.stub(:create).and_return(successful_stripe_response)
-        @user = User.new(email: "test@testign.com", stripe_token: 12345, name: 'tester', password: 'password')
-        @role = FactoryGirl.create(:role, name: "silver")
-        @user.add_role(@role.name)
+      let(:user) { User.new }
+      it 'should create a new stripe account' do
+        StripeAccount.should_receive(:create).with(user)
+        user.update_stripe
       end
+    end
 
-      it "creates a new user with a succesful stripe response" do
-        @user.save!
-        new_user = User.last
-        new_user.customer_id.should eq("youAreSuccessful")
-        new_user.last_4_digits.should eq("4242")
-        new_user.stripe_token.should be_nil
+    context "with an existing user" do
+      let(:user) { FactoryGirl.create(:user, customer_id: '54321', email: 'real@user.com') }
+      before { StripeAccount.stub(:update) }
+      it 'should create a new stripe account' do
+        StripeAccount.should_receive(:update).with(user)
+        user.update_stripe
       end
-
     end
   end
 end


### PR DESCRIPTION
I extracted the stripe methods to their own class. This reduced the method sizes and made them easier to test. It also reduced the large "update_stripe" method in the user model. That thing had a lot of complexity in it. There's still some more that could probably be extracted but this seems to be a good start? thoughts?