### PR TITLE
Removed ability for non-admin to make themselves admin

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -11,8 +11,13 @@ class RegistrationsController < Devise::RegistrationsController
 
   def update_plan
     @user = current_user
-    role = Role.find(params[:user][:role_ids]) unless params[:user][:role_ids].nil?
-    if @user.update_plan(role)
+
+    role_id = params[:user][:role_ids] unless params[:user].nil? || params[:user][:role_ids].nil?
+    role = Role.find_by_id role_id unless role_id.nil?
+
+    authorized = !role.nil? && (role.name != 'admin' || current_user.roles.first.name == 'admin')
+
+    if authorized && @user.update_plan(role)
       redirect_to edit_user_registration_path, :notice => 'Updated plan.'
     else
       flash.alert = 'Unable to update plan.'


### PR DESCRIPTION
When non-admins are changing their role, instead of posting one of the role ids available on the page, they can post the role id of admin role - this assigns them an admin role.

Added a check not to allow non-admins to assign admin roles.
