### PR TITLE
Fixed cancel_subscription

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,7 +72,8 @@ class User < ActiveRecord::Base
     unless customer_id.nil?
       customer = Stripe::Customer.retrieve(customer_id)
       unless customer.nil? or customer.respond_to?('deleted')
-        if customer.subscription.status == 'active'
+        subscription = customer.subscriptions.data[0]
+        if subscription.status == 'active'
           customer.cancel_subscription
         end
       end


### PR DESCRIPTION
Thanks for your work on this sample app. It looks like the Stripe API has changed since this was written. As such, subscription cancellations don't work. The current Stripe API doesn’t have a **subscription.status**, it resides in **customer.subscriptions.data**. Just cancel the first one, since there should only ever be one.
