### PR TITLE
Remove turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'jquery-rails'
-gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,8 +227,6 @@ GEM
     tilt (1.4.1)
     timers (4.0.1)
       hitimes
-    turbolinks (2.5.3)
-      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.1)
@@ -273,6 +271,5 @@ DEPENDENCIES
   spring-commands-rspec
   sqlite3
   sucker_punch
-  turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,5 @@
 //= require jquery
 //= require payola
 //= require jquery_ujs
-//= require turbolinks
 //= require bootstrap-sprockets
 //= require_tree .

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,8 +4,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><%= content_for?(:title) ? yield(:title) : "Rails Stripe Membership" %></title>
     <meta name="description" content="<%= content_for?(:description) ? yield(:description) : "Rails Stripe Membership" %>">
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= javascript_include_tag 'application' %>
     <%= csrf_meta_tags %>
     <%= yield(:head) %>
   </head>


### PR DESCRIPTION
From my brief 10 minutes debugging, I believe having turbolinks is what is causing the issue #116. 

The test suite isn't much help right now but from my own A/B testing having turbolinks installed makes it fail 9/10 times. When I removed turbolinks then buying the product worked 100% of the time. 

Also from the Payola gems documentation:

### Disable Turbolinks

Payola does not currently play nice with turbolinks. Disable it by removing the turoblinks include in your `application.js`.


So we should probably remove it. Here's a pull request doing exactly that. :smile: 