### PR TITLE
Fetch required stripe api keys

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,8 +19,8 @@ development:
   domain_name: example.com
   mailchimp_api_key: <%= ENV["MAILCHIMP_API_KEY"] %>
   mailchimp_list_id: <%= ENV["MAILCHIMP_LIST_ID"] %>
-  stripe_api_key: <%= ENV["STRIPE_API_KEY"] %>
-  stripe_publishable_key: <%= ENV["STRIPE_PUBLISHABLE_KEY"] %>
+  stripe_api_key: <%= ENV.fetch("STRIPE_API_KEY") %>
+  stripe_publishable_key: <%= ENV.fetch("STRIPE_PUBLISHABLE_KEY") %>
   secret_key_base: very_long_random_string
 
 test:
@@ -38,6 +38,6 @@ production:
   domain_name: example.com
   mailchimp_api_key: <%= ENV["MAILCHIMP_API_KEY"] %>
   mailchimp_list_id: <%= ENV["MAILCHIMP_LIST_ID"] %>
-  stripe_api_key: <%= ENV["STRIPE_API_KEY"] %>
-  stripe_publishable_key: <%= ENV["STRIPE_PUBLISHABLE_KEY"] %>
+  stripe_api_key: <%= ENV.fetch("STRIPE_API_KEY") %>
+  stripe_publishable_key: <%= ENV.fetch("STRIPE_PUBLISHABLE_KEY") %>
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
Considering that the app absolutely requires the stripe_api_key and the stripe_publishable_key to function, I'm proposing we fetch those keys. This gives better feedback to the developer. With fetch, as soon as someone tries to start the rails server they will see the message ```(erb):22:in `fetch': key not found: "STRIPE_API_KEY" (KeyError)``` if the keys aren't set.

This will reduce the common issues that people create here on Github when the keys aren't being set. 